### PR TITLE
Fix small typos in message

### DIFF
--- a/etwbreaker.py
+++ b/etwbreaker.py
@@ -124,7 +124,7 @@ class ETWBreaker(idaapi.ida_idaapi.plugin_t):
         try:
             providers += parse_manifest(find_wevt_template(*find_segment(".rsrc")[0]))
         except IndexError:
-            ETWBreaker.log("Please concider to reload the file and check the 'Load Resource' checkbox")
+            ETWBreaker.log("Please consider reloading the file and check the 'Load resources' checkbox")
         except ETWBreakerException as e:
             ETWBreaker.log(str(e))
 


### PR DESCRIPTION
This isn't much but I think it can help

Proof of "Load resources":
![image](https://user-images.githubusercontent.com/550823/177871207-40976d78-5471-4eec-850d-6e896773f048.png)
